### PR TITLE
Fix: Position is incorrect on OSX and Linux

### DIFF
--- a/cross.py
+++ b/cross.py
@@ -33,7 +33,7 @@ class CrossListener(sublime_plugin.EventListener):
 			end_sel = sel.end()
 			pos_xy = view.text_to_layout(end_sel)
 			pos_x = pos_xy[0]
-			pos = int(pos_x/view.em_width())
+			pos = pos_x/view.em_width()
 			rulers.append(pos)
 			if not show_multiple_cross:
 				break


### PR DESCRIPTION
If there are characters other than ASCII in a line, the position of ruler(s) could be a float.
